### PR TITLE
fix(select-status): #CO-1782 preselect new status when updating ticket

### DIFF
--- a/src/main/resources/public/template/edit-ticket.html
+++ b/src/main/resources/public/template/edit-ticket.html
@@ -56,8 +56,8 @@
 		<div class="row">
 			<label class="two cell"><i18n>support.ticket.new.comment</i18n></label>
 			<div class="ten cell">
-				<textarea ng-model="editedTicket.newComment" ng-if="!isRichEditorActivated" ng-change="changeStatusWhenAddingComment()" input-guard></textarea>
-				<editor ng-model="editedTicket.newComment" ng-if="isRichEditorActivated" ng-change="changeStatusWhenAddingComment()" input-guard></editor>
+				<textarea ng-model="editedTicket.newComment" ng-if="!isRichEditorActivated" input-guard></textarea>
+				<editor ng-model="editedTicket.newComment" ng-if="isRichEditorActivated" input-guard></editor>
 			</div>
 			<div class="ten cell right-magnet" ng-if="ticket.attachments !== undefined && !ticket.attachments.isEmpty()">
 				<br>

--- a/src/main/resources/public/template/edit-ticket.html
+++ b/src/main/resources/public/template/edit-ticket.html
@@ -56,8 +56,8 @@
 		<div class="row">
 			<label class="two cell"><i18n>support.ticket.new.comment</i18n></label>
 			<div class="ten cell">
-				<textarea ng-model="editedTicket.newComment" ng-if="!isRichEditorActivated" input-guard></textarea>
-				<editor ng-model="editedTicket.newComment" ng-if="isRichEditorActivated" input-guard></editor>
+				<textarea ng-model="editedTicket.newComment" ng-if="!isRichEditorActivated" ng-change="changeStatusWhenAddingComment()" input-guard></textarea>
+				<editor ng-model="editedTicket.newComment" ng-if="isRichEditorActivated" ng-change="changeStatusWhenAddingComment()" input-guard></editor>
 			</div>
 			<div class="ten cell right-magnet" ng-if="ticket.attachments !== undefined && !ticket.attachments.isEmpty()">
 				<br>

--- a/src/main/resources/public/ts/controllers/controller.ts
+++ b/src/main/resources/public/ts/controllers/controller.ts
@@ -302,14 +302,10 @@ export const SupportController: Controller = ng.controller('SupportController',
 		$scope.preSelectNewTicketStatus = async (): Promise<void> => {
 			if ($scope.userIsLocalAdmin($scope.ticket) && $scope.ticket.status == model.ticketStatusEnum.NEW) {
 				$scope.editedTicket.status = model.ticketStatusEnum.OPENED
+			} else if ($scope.userIsLocalAdmin($scope.ticket) && $scope.ticket.status == model.ticketStatusEnum.OPENED) {
+				$scope.editedTicket.status = model.ticketStatusEnum.WAITING
 			} else if (!$scope.userIsLocalAdmin($scope.ticket) && $scope.ticket.status == model.ticketStatusEnum.WAITING) {
 				$scope.editedTicket.status = model.ticketStatusEnum.OPENED
-			}
-		}
-
-		$scope.changeStatusWhenAddingComment = async (): Promise<void> => {
-			if ($scope.userIsLocalAdmin($scope.ticket) && $scope.ticket.status == model.ticketStatusEnum.OPENED && $scope.editedTicket.newComment.length > 0){
-				$scope.editedTicket.status = model.ticketStatusEnum.WAITING
 			}
 		}
 

--- a/src/main/resources/public/ts/controllers/controller.ts
+++ b/src/main/resources/public/ts/controllers/controller.ts
@@ -299,11 +299,17 @@ export const SupportController: Controller = ng.controller('SupportController',
 			}
 		}
 
-		$scope.changeUpdatingTicketStatus = async (): Promise<void> => {
-			if ($scope.userIsLocalAdmin($scope.ticket) && $scope.ticket.status == model.ticketStatusEnum.OPENED) {
-				$scope.ticket.status = model.ticketStatusEnum.WAITING
+		$scope.preSelectNewTicketStatus = async (): Promise<void> => {
+			if ($scope.userIsLocalAdmin($scope.ticket) && $scope.ticket.status == model.ticketStatusEnum.NEW) {
+				$scope.editedTicket.status = model.ticketStatusEnum.OPENED
 			} else if (!$scope.userIsLocalAdmin($scope.ticket) && $scope.ticket.status == model.ticketStatusEnum.WAITING) {
-				$scope.ticket.status = model.ticketStatusEnum.OPENED
+				$scope.editedTicket.status = model.ticketStatusEnum.OPENED
+			}
+		}
+
+		$scope.changeStatusWhenAddingComment = async (): Promise<void> => {
+			if ($scope.userIsLocalAdmin($scope.ticket) && $scope.ticket.status == model.ticketStatusEnum.OPENED && $scope.editedTicket.newComment.length > 0){
+				$scope.editedTicket.status = model.ticketStatusEnum.WAITING
 			}
 		}
 
@@ -522,6 +528,7 @@ export const SupportController: Controller = ng.controller('SupportController',
 		// Update ticket
 		$scope.editTicket = function() {
 			$scope.editedTicket = $scope.ticket;
+			$scope.preSelectNewTicketStatus();
 			template.open('main', 'edit-ticket');
 		};
 
@@ -583,7 +590,6 @@ export const SupportController: Controller = ng.controller('SupportController',
 
 			$scope.createProtectedCopies($scope.editedTicket, false, function() {
 				$scope.ticket = $scope.editedTicket;
-				$scope.changeUpdatingTicketStatus();
 				$scope.ticket.updateTicket($scope.ticket, function() {
 					if($scope.ticket.newAttachments && $scope.ticket.newAttachments.length > 0) {
 						$scope.ticket.getAttachments();


### PR DESCRIPTION
## Describe your changes
Now when you want to update a ticket (add comments for example) it will preselect the new status depending of your role and the current status.
The selected status in the select box now correctly matter when you update a ticket 
## Checklist tests

- As an ADML, update a ticket with the status "NEW" and check if the select box is automatically changed to "OPEN"
 then, if the status is on "OPEN" check if when you write a comment, the status will change to "WAITING"
- As a user, update a ticket with the status "WAITING" and check if the select box is automatically changed to "OPEN"

## Issue ticket number and link
[CO-1782](https://jira.support-ent.fr/browse/CO-1782) & [CO-1783](https://jira.support-ent.fr/browse/CO-1783)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

