### PR TITLE
Fix coco 4342 add push notif in zendesk escalation

### DIFF
--- a/src/main/java/net/atos/entng/support/services/impl/EscalationServicePivotImpl.java
+++ b/src/main/java/net/atos/entng/support/services/impl/EscalationServicePivotImpl.java
@@ -1,6 +1,7 @@
 package net.atos.entng.support.services.impl;
 
 import fr.wseduc.webutils.Either;
+import fr.wseduc.webutils.I18n;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -293,6 +294,8 @@ public class EscalationServicePivotImpl implements EscalationService
 
         String ticketOwner = issue.getString("owner_id");
         String structure = issue.getString("school_id");
+        String username = user.getString("username");
+
         final Set<String> recipientSet = new HashSet<>();
         String notificationName = getNotificationName( issueStatus );
 
@@ -310,12 +313,24 @@ public class EscalationServicePivotImpl implements EscalationService
             if (!recipients.isEmpty()) {
                 JsonObject params = new JsonObject();
                 params.put("issueId",ticket_id_iws)
-                        .put("username", user.getString("username"))
+                        .put("username", username)
                         .put("ticketId", ticketId);
                 params.put("ticketUri", "/support#/ticket/" + ticketId);
                 params.put("resourceUri", params.getString("ticketUri"))
                         .put("ticketsubject", shortenSubject(issue.getString("description") ));
                 params.put("resourceUri", params.getString("ticketUri"));
+
+                JsonObject pushNotif = new JsonObject()
+                        .put("title", "push-notif.support." + notificationName)
+                        .put("body", I18n.getInstance()
+                                .translate(
+                                        "push-notif." + notificationName + ".body",
+                                        I18n.DEFAULT_DOMAIN,
+                                        issue.getString("locale", "fr"),
+                                        username,
+                                        ticketId
+                                ));
+                params.put("pushNotif", pushNotif);
 
                 notification.notifyTimeline(null, "support." + notificationName, null, recipients, params);
             }

--- a/src/main/java/net/atos/entng/support/services/impl/EscalationServiceZendeskImpl.java
+++ b/src/main/java/net/atos/entng/support/services/impl/EscalationServiceZendeskImpl.java
@@ -1250,6 +1250,8 @@ public class EscalationServiceZendeskImpl implements EscalationService {
 											));
 							params.put("pushNotif", pushNotif);
 
+							log.info("Sending notification to " + String.valueOf(ticket.id.get()));
+
 							notification.notifyTimeline(null, "support." + notificationName, null, recipients, null, params);
 						}
 					}

--- a/src/main/java/net/atos/entng/support/services/impl/EscalationServiceZendeskImpl.java
+++ b/src/main/java/net/atos/entng/support/services/impl/EscalationServiceZendeskImpl.java
@@ -1236,6 +1236,11 @@ public class EscalationServiceZendeskImpl implements EscalationService {
 							params.put("ticketUri", "/support#/ticket/" + ticket.id.get());
 							params.put("resourceUri", params.getString("ticketUri"));
 
+							String supportName = I18n.getInstance()
+									.translate("support",
+													I18n.DEFAULT_DOMAIN,
+													ticket.locale);
+
 							JsonObject pushNotif = new JsonObject()
 									.put("title", "push-notif.support." + notificationName)
 									.put("body", I18n.getInstance()
@@ -1245,7 +1250,7 @@ public class EscalationServiceZendeskImpl implements EscalationService {
 													ticket.locale,
 													//Requière l'intégration d'un nouveau endpoint de zendesk pour récupérer les audits du ticket
 													//afin d'extraire le nom de la dernière personne ayant modifiée
-													"Zendesk",
+													supportName,
                                                     String.valueOf(ticket.id.get())
 											));
 							params.put("pushNotif", pushNotif);

--- a/src/main/java/net/atos/entng/support/services/impl/EscalationServiceZendeskImpl.java
+++ b/src/main/java/net/atos/entng/support/services/impl/EscalationServiceZendeskImpl.java
@@ -1223,17 +1223,32 @@ public class EscalationServiceZendeskImpl implements EscalationService {
 						{
 							String notificationName;
 
-							if (ZendeskStatus.solved.equals(newStatus) && newStatus.equals(oldStatus) == false)
+							if (ZendeskStatus.solved.equals(newStatus) && !newStatus.equals(oldStatus)) {
 								notificationName = "bugtracker-issue-resolved";
-							else if (ZendeskStatus.closed.equals(newStatus) && newStatus.equals(oldStatus) == false)
+							} else if (ZendeskStatus.closed.equals(newStatus) && !newStatus.equals(oldStatus)) {
 								notificationName = "bugtracker-issue-closed";
-							else
+							} else {
 								notificationName = "bugtracker-issue-updated";
+							}
 
 							JsonObject params = new JsonObject();
 							params.put("issueId", issue.id.get()).put("ticketId", ticket.id.get());
 							params.put("ticketUri", "/support#/ticket/" + ticket.id.get());
 							params.put("resourceUri", params.getString("ticketUri"));
+
+							JsonObject pushNotif = new JsonObject()
+									.put("title", "push-notif.support." + notificationName)
+									.put("body", I18n.getInstance()
+											.translate(
+													"push-notif." + notificationName + ".body",
+													I18n.DEFAULT_DOMAIN,
+													ticket.locale,
+													//Requière l'intégration d'un nouveau endpoint de zendesk pour récupérer les audits du ticket
+													//afin d'extraire le nom de la dernière personne ayant modifiée
+													"Zendesk",
+                                                    String.valueOf(ticket.id.get())
+											));
+							params.put("pushNotif", pushNotif);
 
 							notification.notifyTimeline(null, "support." + notificationName, null, recipients, null, params);
 						}

--- a/src/main/java/net/atos/entng/support/services/impl/TicketServiceSqlImpl.java
+++ b/src/main/java/net/atos/entng/support/services/impl/TicketServiceSqlImpl.java
@@ -482,7 +482,7 @@ public class TicketServiceSqlImpl extends SqlCrudService implements TicketServic
 	 */
 	private String escalateTicketInfoQuery( String fromTable, String whereClause )  {
 		return "SELECT t.id, t.status, t.subject, t.description, t.category, t.school_id,"
-		+ " u.username AS owner_name, t.owner as owner_id, t.created,"
+		+ " u.username AS owner_name, t.owner as owner_id, t.created, t.locale,"
 				+ " CASE WHEN COUNT(a.document_id) = 0 THEN '[]' ELSE json_agg(DISTINCT a.document_id) END AS attachments,"
 				+ " CASE WHEN COUNT(a.name) = 0 THEN '[]' ELSE json_agg(DISTINCT a.name) END AS attachmentsNames,"
 		+ " CASE WHEN COUNT(c.id) = 0 THEN '[]' "


### PR DESCRIPTION
## Describe your changes

Le processus de resynchronisation régulier de zendesk n'inclut pas de pushnotification en cas de mise à jour de ticket côté zendesk. Ajout de la push notification, en utilisant le domaine par défaut, la langue du ticket, et en utilisant "Assistance ENT" comme modificateur du ticket pour la push notification. Prendre le nom du modificateur requière l'intégration d'un nouveau endpoint pour récupérer l'audit de chaque ticket modifié afin d'extraire le nom du dernier modificateur.
J'ai également corrigé la partie pivotal pour ajouter la push notification

## Issue ticket number and link

https://edifice-community.atlassian.net/browse/COCO-4342

## Tests

Créez un ticket sur l'assistance sur une plateforme intégrant Zendesk (je ne sais si il faut le faire par zendesk pour que le ticket existe dans les deux systèmes). Escaldez puis Modifiez le ticket dans zendesk. Une pushnotification devrait partir pour les adml locaux et le owner du ticket.

Créez un ticket sur l'assistance sur une plateforme intégrant Pivotal. Escaladez, modifiez le ticket dans pivotal. Une pushnotification devrait partir pour les adml locaux et le owner du ticket.


## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

