### PR TITLE
fix-(support): #COCO-4734 fix potgresql row index use in return of update ticket

### DIFF
--- a/src/main/java/net/atos/entng/support/controllers/TicketController.java
+++ b/src/main/java/net/atos/entng/support/controllers/TicketController.java
@@ -359,7 +359,6 @@ public class TicketController extends ControllerHelper {
                     // TODO : do not authorize description update if there is a comment
                     ticketServiceSql.updateTicket(ticketId, ticket, user,
                             getCreateOrUpdateTicketHandler(request, user, ticket, ticketId));
-                    //notifyTicketUpdated(request, user, ticket);
                 });
             } else {
                 log.debug("User not found in session.");

--- a/src/main/java/net/atos/entng/support/services/impl/TicketServiceSqlImpl.java
+++ b/src/main/java/net/atos/entng/support/services/impl/TicketServiceSqlImpl.java
@@ -110,6 +110,8 @@ public class TicketServiceSqlImpl extends SqlCrudService implements TicketServic
 		// 2. Update ticket
 		StringBuilder sb = new StringBuilder();
 		JsonArray values = new JsonArray();
+		//numéro de la ligne contenant les informations du ticket
+		int index = 1;
 		for (String attr : data.fieldNames()) {
 			// COCO-4341 Update description iif ticket is not already escalated.
 			if("description".equals(attr)) {
@@ -121,6 +123,7 @@ public class TicketServiceSqlImpl extends SqlCrudService implements TicketServic
 					.add(EscalationStatus.IN_PROGRESS.status())
 					.add(EscalationStatus.SUCCESSFUL.status())
 				);
+				index++;
 				continue;
 			}
 
@@ -169,7 +172,7 @@ public class TicketServiceSqlImpl extends SqlCrudService implements TicketServic
 		this.insertAttachments(attachments, user, s, ticketId);
 
 		// Send queries to event bus
-		sql.transaction(s.build(), validUniqueResultHandler(1, toTicketHandler(handler, attachments)));
+		sql.transaction(s.build(), validUniqueResultHandler(index, toTicketHandler(handler, attachments)));
 	}
 
 


### PR DESCRIPTION
## Describe your changes

Une mise à jour sur support a provoqué une regression en décalant l'index de la ligne de resultat SQL retourné lors de la mise à jour des informations d'un ticket => calcul du bon index

## Checklist tests

## Issue ticket number and link

https://edifice-community.atlassian.net/browse/COCO-4734

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

